### PR TITLE
feat: Install and configure backend test suite

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -45,10 +45,93 @@ def create_contributing
   template 'templates/CONTRIBUTING.md.tt', 'CONTRIBUTING.md'
 end
 
+def add_test_gem_group
+  gem_group :test do
+  end
+end
+
+def add_simplecov
+  insert_into_file 'Gemfile', after: "group :test do" do
+    "\tgem 'simplecov', require: false\n"
+  end
+end
+
+def add_webmock
+  insert_into_file 'Gemfile', after: "group :development, :test do" do
+    "\n\tgem 'webmock'\n"
+  end
+end
+
+def add_shoulda_matchers
+  insert_into_file 'Gemfile', after: "group :test do" do
+    "\n\tgem 'shoulda-matchers', '~> 4.0'\n"
+  end
+end
+
+def add_climate_control
+  insert_into_file 'Gemfile', after: "group :test do" do
+    "\n\tgem 'climate_control'\n"
+  end
+end
+
+def add_factory_bot
+  insert_into_file 'Gemfile', after: "group :development, :test do" do
+    "\n\tgem 'factory_bot_rails'\n"
+  end
+end
+
+def add_rspec
+  insert_into_file 'Gemfile', after: "group :development, :test do" do
+    "\n\tgem 'rspec-rails', '~> 4.0.1'\n"
+  end
+end
+
+def create_factory_bot_support
+  template 'templates/spec/support/factory_bot.rb', 'spec/support/factory_bot.rb'
+  insert_into_file 'spec/rails_helper.rb', after: '# Add additional requires below this line. Rails is not loaded until this point!' do
+    "require 'support/factory_bot'\n"
+  end
+end
+
+def create_shoulda_matchers_support
+  template 'templates/spec/support/shoulda_matchers.rb', 'spec/support/shoulda_matchers.rb'
+  append_to_file 'spec/rails_helper.rb', "require 'support/shoulda-matchers'\n"
+end
+
+def create_simplecov_support
+  prepend_to_file 'spec/spec_helper.rb', "require 'simplecov'\nSimpleCov.start 'rails'\n\n"
+end
+
+def create_webmock_support
+  insert_into_file 'spec/rails_helper.rb', after: '# Add additional requires below this line. Rails is not loaded until this point!' do
+    "\nrequire 'webmock/rspec'\n"
+  end
+end
+
+def stop_spring
+  run "spring stop"
+end
+
+def add_backend_test_tools
+  add_test_gem_group
+  add_factory_bot
+  add_simplecov
+  add_shoulda_matchers
+  add_webmock
+  add_rspec
+end
+
 source_paths
+add_backend_test_tools
 
 after_bundle do
   create_docs
   create_readme
   create_contributing
+  stop_spring
+  generate "rspec:install"
+  create_factory_bot_support
+  create_shoulda_matchers_support
+  create_simplecov_support
+  create_webmock_support
 end

--- a/templates/spec/support/factory_bot.rb
+++ b/templates/spec/support/factory_bot.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'factory_bot_rails'
+
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/templates/spec/support/shoulda_matchers.rb
+++ b/templates/spec/support/shoulda_matchers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require 'shoulda-matchers'
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Adds support for:

- rspec
- webmock
- factory_bot
- simplecov
- shoulda-matchers

Each dependency is added to the Gemfile and any supporting files generated after bundle and installation of rspec. I decided to separate out the function calls to install the dependencies. In future it could be possible to parameterise what testing tools are created, provide CLI options to install some test tools and not others.

Closes #2 