### PR TITLE
feat: Rename git main branch to `main`

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -190,4 +190,7 @@ after_bundle do
   create_webmock_support
   create_dev_procfile({ sidekiq: sidekiq })
   create_rubocop_yml
+  git checkout: '-b main'
+  git add: '-A .'
+  git commit: '-m "setup: GOVUK Rails app setup complete"'
 end


### PR DESCRIPTION
Naming conventions like `master:slave` in computing are oppressive language. We favour `main` branch over `master`.

Closes #17 